### PR TITLE
an initial implementation of an external-file driven io wrapper for the ZTD benchmarks

### DIFF
--- a/Example.py
+++ b/Example.py
@@ -103,4 +103,7 @@ def nice_plot_SPEA_2():
     plt.show()
 
 
-nice_plot_SPEA_2()
+
+if __name__ == "__main__":
+    run_test_problems()
+#nice_plot_SPEA_2()

--- a/io_wrapper.py
+++ b/io_wrapper.py
@@ -9,6 +9,15 @@ test_dict = {"zdt1": ts.ZDT1, "zdt2": ts.ZDT2, "zdt3": ts.ZDT3, "zdt4": ts.ZDT4,
 
 
 def parse():
+    """ parse the command args
+
+    Parameters
+    ----------
+        None
+
+    Returns
+        args : ArgumentParser instance parsed arguments from the command line
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument("--test_function", nargs=1, dest="test_function", default="zdt1")
     parser.add_argument("--input", nargs=1, default="input.dat", dest="input_file")
@@ -18,8 +27,17 @@ def parse():
 
 
 def run_through_wrapper(args):
+    """run a given ZDT benchmark via an input and output file
 
-    # io_wrapper(args.test_function,args.input_file,args.output_file)
+    Parameters
+    ----------
+        args : ArgumentParser instance parsed arguments from the command line
+
+    Returns
+    -------
+        None
+    """
+
     test_function = args.test_function.lower()
     if test_function not in test_dict.keys():
         raise Exception("'test_function' {0} not found in test suite", format(test_function))
@@ -35,6 +53,9 @@ def run_through_wrapper(args):
         f.write("f2 {0:20.8E}\n".format(f2))
 
 def test_wrapper():
+    """test that the io wrapper is doing something...
+
+    """
     args = parse()
     names = ["par_{0:02d}".format(i) for i in range(30)]
     vals = np.zeros(30) + 0.5

--- a/io_wrapper.py
+++ b/io_wrapper.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import argparse
+import numpy as np
+import pandas as pd
+import Test_suite as ts
+
+test_dict = {"zdt1": ts.ZDT1, "zdt2": ts.ZDT2, "zdt3": ts.ZDT3, "zdt4": ts.ZDT4, "zdt6": ts.ZDT6}
+
+
+def parse():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--test_function", nargs=1, dest="test_function", default="zdt1")
+    parser.add_argument("--input", nargs=1, default="input.dat", dest="input_file")
+    parser.add_argument("--output", nargs=1, default="output.dat", dest="output_file")
+
+    return parser.parse_args()
+
+
+def run_through_wrapper(args):
+
+    # io_wrapper(args.test_function,args.input_file,args.output_file)
+    test_function = args.test_function.lower()
+    if test_function not in test_dict.keys():
+        raise Exception("'test_function' {0} not found in test suite", format(test_function))
+    tf = test_dict[test_function]
+    try:
+        input_df = pd.read_csv(args.input_file)
+    except Exception as e:
+        raise Exception("error reading input file {0}:{1}".format(args.input_file,str(e)))
+    f1 = tf.f1(input_df.parval1)
+    f2 = tf.f2(input_df.parval1)
+    with open(args.output_file,'w') as f:
+        f.write("f1 {0:20.8E}\n".format(f1))
+        f.write("f2 {0:20.8E}\n".format(f2))
+
+def test_wrapper():
+    args = parse()
+    names = ["par_{0:02d}".format(i) for i in range(30)]
+    vals = np.zeros(30) + 0.5
+    df = pd.DataFrame({"parnme":names,"parval1":vals})
+    df.to_csv("input.dat")
+    run_through_wrapper(args)
+    assert os.path.exists(args.output_file)
+    df = pd.read_csv(args.output_file,delim_whitespace=True,header=None)
+    print(df)
+
+if __name__ == "__main__":
+    #run_through_wrapper()
+    test_wrapper()


### PR DESCRIPTION
@ore13 - here is a poor attempt to wrap the ZDT benchmarks with an external file wrapper just to give you an idea of what I was talking about.  

I realized that we might need to check that the `x` vector being passed `f1` and `f2` for each of the benchmarks has the correct number of decision variables (some take 30 and others take 10, right?).    